### PR TITLE
Omit null errors from output

### DIFF
--- a/jslint-server/src/server.ts
+++ b/jslint-server/src/server.ts
@@ -456,7 +456,7 @@ class Linter {
 		}
 		const isLegacy = Array.isArray(output.errors);
 		const fudge = isLegacy ? 0 : 1; // old jslint versions use 1-based lines/columns, modern versions use 0-based
-		const warnings = isLegacy ? output.errors : output.warnings;
+		const warnings = isLegacy ? output.errors.filter(Boolean) : output.warnings;
 		return warnings.map(function (warning, i) {
 			return {
 				code: warning.code,


### PR DESCRIPTION
The legacy linters will [emit `null` if a stopping error is found](https://github.com/reid/node-jslint/blob/master/lib/jslint-2014-07-08.js#L61-L64), which results in an exception when translating the warnings (accessing `warning.code` throws).
